### PR TITLE
ignore blank lines sent by the Redis server

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -66,6 +66,9 @@ def parse_info(info_lines):
     """Parse info response from Redis"""
     info = {}
     for line in info_lines:
+        if "" == line:
+            continue
+        
         if ':' not in line:
             collectd.warning('redis_info plugin: Bad format for info line: %s'
                              % line)


### PR DESCRIPTION
While testing on a Redis 2.4.10 server, I got "redis_info plugin: Bad format for info line:" because Redis sends an extra blank line at the end of the output from the INFO command. This patch ignores blank lines returned from the Redis server.
