### PR TITLE
suppress bad format warnings

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -59,16 +59,18 @@ def fetch_info():
     data = fp.read(content_length)
     log_verbose('Received data: %s' % data)
     s.close()
-    return parse_info(data.split("\n"))
+
+    linesep = '\r\n' if '\r\n' in data else '\n'
+    return parse_info(data.split(linesep))
 
 
 def parse_info(info_lines):
     """Parse info response from Redis"""
     info = {}
     for line in info_lines:
-        if "" == line:
+        if "" == line or line.startswith('#'):
             continue
-        
+
         if ':' not in line:
             collectd.warning('redis_info plugin: Bad format for info line: %s'
                              % line)


### PR DESCRIPTION
Using your script with `redis-2.6.2` results in numerous `Bad format for info line:` warnings. This patch suppresses them. Example warnings and partial info output:

```
...
mem_fragmentation_ratio:1.86
mem_allocator:jemalloc-3.0.0

# Persistence
loading:0
rdb_changes_since_last_save:0
...

[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # Server
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: 
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # Clients
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: 
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # Memory
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: 
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # Persistence
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: 
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # Stats
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: 
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # Replication
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: 
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # CPU
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: 
[2012-11-05 02:24:38] redis_info plugin: Bad format for info line: # Keyspace
```

The empty lines are actually `\r` characters. I don't know if that what the case was in previous versions, but the current redis [protocol spec](http://redis.io/topics/protocol) states that CLRF line endings should be used. Cheers.
