### PR TITLE
report evicted_keys

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -140,6 +140,7 @@ def read_callback():
     dispatch_value(info, 'connected_clients', 'gauge')
     dispatch_value(info, 'connected_slaves', 'gauge')
     dispatch_value(info, 'blocked_clients', 'gauge')
+    dispatch_value(info, 'evicted_keys', 'gauge')
     dispatch_value(info, 'used_memory', 'bytes')
     dispatch_value(info, 'changes_since_last_save', 'gauge')
     dispatch_value(info, 'total_connections_received', 'counter',


### PR DESCRIPTION
It's a handy stat, especially when redis is configured in an LRU mode.
