### PR TITLE
allow collecting stats from multi redis instances in one mahcine

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -144,6 +144,7 @@ def dispatch_value(info, key, type, plugin_instance=None, type_instance=None):
 
     if not plugin_instance:
         plugin_instance = 'unknown redis'
+        collectd.error('redis_info plugin: plugin_instance is not set, Info key: %s' % key)
 
     if not type_instance:
         type_instance = key


### PR DESCRIPTION
This merge enables you to configure to monitor multi redis instances in the same machine, such as:
```
<Plugin python>
  ModulePath "/opt/collectd_plugins"
  Import "redis_info"

  <Module redis_info>
    Host "127.0.0.1"
    Port 9100
    Verbose true
  </Module>

  <Module redis_info>
    Host "127.0.0.1"
    Port 9101
    Verbose true
  </Module>
  <Module redis_info>
    Host "127.0.0.1"
    Port 9102
    Verbose true
  </Module>
</Plugin>
``` 

These 3 redis instances listen on different ports, they have different `plugin_instance` combined by `Host` and `Port`:
```
"plugin_instance" => "127.0.0.1:9100",
"plugin_instance" => "127.0.0.1:9101",
"plugin_instance" => "127.0.0.1:9102",
```