### PR TITLE
Send keyspace_hits and keyspace_misses

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -190,6 +190,10 @@ def get_metrics( conf ):
     dispatch_value(info, 'total_commands_processed', 'counter', plugin_instance,
                    'commands_processed')
 
+    # send keyspace hits and misses, if they exist
+    if 'keyspace_hits' in info: dispatch_value(info, 'keyspace_hits', 'derive', plugin_instance)
+    if 'keyspace_misses' in info: dispatch_value(info, 'keyspace_misses', 'derive', plugin_instance)
+
     # send replication stats, but only if they exist (some belong to master only, some to slaves only)
     if 'master_repl_offset' in info: dispatch_value(info, 'master_repl_offset', 'gauge', plugin_instance)
     if 'master_last_io_seconds_ago' in info: dispatch_value(info, 'master_last_io_seconds_ago', 'gauge', plugin_instance)


### PR DESCRIPTION
Chose 'derive' type since the recent change in hits/misses is more
interesting than the total.

These metrics were added to Redis's INFO command in Oct 2010,
so they've been there quite a while. Still we check to make sure
they exist in case user has an old version of redis.

Originally added to Redis: https://github.com/antirez/redis/commit/53eeeaff08