### PR TITLE
feature: adding 3 new data capture

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -184,7 +184,10 @@ def get_metrics( conf ):
     dispatch_value(info, 'blocked_clients', 'gauge', plugin_instance)
     dispatch_value(info, 'evicted_keys', 'gauge', plugin_instance)
     dispatch_value(info, 'used_memory', 'bytes', plugin_instance)
+    dispatch_value(info, 'used_memory_peak', 'bytes', plugin_instance)
     dispatch_value(info, 'changes_since_last_save', 'gauge', plugin_instance)
+    dispatch_value(info, 'instantaneous_ops_per_sec', 'gauge', plugin_instance)
+    dispatch_value(info, 'rdb_bgsave_in_progress', 'gauge', plugin_instance)
     dispatch_value(info, 'total_connections_received', 'counter', plugin_instance,
                    'connections_received')
     dispatch_value(info, 'total_commands_processed', 'counter', plugin_instance,


### PR DESCRIPTION
Hi,

I think it would be nice to include those 3 metrics:
- used_memory_peak: it's nice to know what is the max held and when it
  has reach it
- instantaneous_ops_per_sec: several operations can be performed (bulk
  included), it's good to know it
- rdb_bgsave_in_progress: to know how many time a bgsave can occur in a
  day and how long

Thanks