### PR TITLE
Fix error when info is None

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -198,6 +198,9 @@ def dispatch_value(info, key, type, plugin_instance=None, type_instance=None):
         value = int(info[key])
     except ValueError:
         value = float(info[key])
+    except TypeError:
+        log_verbose('No info for key: %s' % key)
+        return
 
     log_verbose('Sending value: %s=%s' % (type_instance, value))
 


### PR DESCRIPTION
Trackback:
[2017-04-28 16:43:23] Unhandled python exception in read callback: TypeError: int() argument must be a string or a number, not 'NoneType'
[2017-04-28 16:43:23] Traceback (most recent call last):
[2017-04-28 16:43:23]   File "/usr/lib/collectd/redis_info.py", line 216, in read_callback
    get_metrics(conf)
[2017-04-28 16:43:23]   File "/usr/lib/collectd/redis_info.py", line 238, in get_metrics
    dispatch_value(info, key, val, plugin_instance)
[2017-04-28 16:43:23]   File "/usr/lib/collectd/redis_info.py", line 200, in dispatch_value
    value = int(info[key])