### PR TITLE
support redis cluster info metrics

### DIFF
--- a/redis_info.py
+++ b/redis_info.py
@@ -96,8 +96,8 @@ def fetch_info(conf):
     status_line = fp.readline()
     log_verbose('Received line: %s' % status_line)
     content_length = int(status_line[1:-1])  # status_line looks like: $<content_length>
-    datacluster_dict = fp.read(content_length)  # fetch cluster info to different data buffer
-    log_verbose('Received data: %s' % datacluster_dict)
+    datacluster = fp.read(content_length)  # fetch cluster info to different data buffer
+    log_verbose('Received data: %s' % datacluster)
 
     s.close()
 

--- a/redis_info.py
+++ b/redis_info.py
@@ -88,19 +88,34 @@ def fetch_info(conf):
     content_length = int(status_line[1:-1])  # status_line looks like: $<content_length>
     datac = fp.read(content_length)  # fetch commandstats to different data buffer
     log_verbose('Received data: %s' % datac)
+    
+    # process 'cluster info'
+    log_verbose('Sending cluster info command')
+    s.sendall('cluster info\r\n')
+    fp.readline()  # skip first line in the response because it is empty
+    status_line = fp.readline()
+    log_verbose('Received line: %s' % status_line)
+    content_length = int(status_line[1:-1])  # status_line looks like: $<content_length>
+    datacluster_dict = fp.read(content_length)  # fetch cluster info to different data buffer
+    log_verbose('Received data: %s' % datacluster_dict)
 
     s.close()
 
     linesep = '\r\n' if '\r\n' in data else '\n'  # assuming all is done in the same connection...
     data_dict = parse_info(data.split(linesep))
     datac_dict = parse_info(datac.split(linesep))
+    datacluster_dict = parse_info(datacluster.split(linesep))
+
     # let us see more raw data just in case
     log_verbose('Data: %s' % len(data_dict))
     log_verbose('Datac: %s' % len(datac_dict))
+    log_verbose('Datacluster: %s' % len(datacluster_dict))
 
-    # merge two data sets into one
+    # merge three data sets into one
     data_full = data_dict.copy()
     data_full.update(datac_dict)
+    data_full.update(datacluster_dict)
+
     log_verbose('Data Full: %s' % len(data_full))
 
     # this generates hundreds of lines but helps in debugging a lot


### PR DESCRIPTION
redis' info command only contain one value for cluster support:
```
127.0.0.1:8690> info cluster
# Cluster
cluster_enabled:1
```

More information are in "cluster info" command response. 

when enable redis cluster:

```
127.0.0.1:8690> cluster info
cluster_state:ok
cluster_slots_assigned:16384
cluster_slots_ok:16384
cluster_slots_pfail:0
cluster_slots_fail:0
cluster_known_nodes:6
cluster_size:3
cluster_current_epoch:6
cluster_my_epoch:4
cluster_stats_messages_sent:73807
cluster_stats_messages_received:73690
```

when not enable redis cluster:
```
127.0.0.1:8690> cluster info
cluster_state:fail
cluster_slots_assigned:0
cluster_slots_ok:0
cluster_slots_pfail:0
cluster_slots_fail:0
cluster_known_nodes:1
cluster_size:0
cluster_current_epoch:0
cluster_my_epoch:0
cluster_stats_messages_sent:0
cluster_stats_messages_received:0
```
test result:

Sep 11 05:54:52 redis001 collectd[25658]: redis plugin [verbose]: Data Full detail: cluster_known_nodes = 6


So add this support for cluster info.

@powdahound  Thanks for your review.


![circonus check information rediscluster redis005 - google chrome](https://user-images.githubusercontent.com/5654180/30262747-b1694f16-9704-11e7-9441-f2fefb1290d0.jpg)
