### PR TITLE
Allow disabling cluster mode info collection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Notice, you will have to adjust *cmdset* section depending on the Redis version,
         Port 6379
         # Un-comment to use AUTH
         #Auth "1234"
+        # Cluster mode expected by default
+        #Cluster false
         Verbose false
         #Instance "instance_1"
         # Redis metrics to collect (prefix with Redis_)

--- a/redis.conf
+++ b/redis.conf
@@ -13,6 +13,8 @@
     Port 6379
     # Un-comment to use AUTH
     #Auth "1234"
+    # Cluster mode expected by default
+    #Cluster false
     Verbose false
     # Catch Redis metrics (prefix with Redis_)
     Redis_uptime_in_seconds "gauge"


### PR DESCRIPTION
Thanks for sharing your plugin. When connecting to a standalone (non-clustered) Redis instance, the plugin (with all the ```Redis_cmdstat_``` configs commented out) prints out the following:
```
collectd_1  | read-function of plugin `python.redis_info' failed. Will suspend it for 80.000 seconds.
collectd_1  | redis plugin [verbose]: Connected to Redis at redis:6379
collectd_1  | redis plugin [verbose]: Sending info command
collectd_1  | redis plugin [verbose]: Received data: # Server
collectd_1  | redis_version:4.0.4
collectd_1  | redis_git_sha1:00000000
collectd_1  | redis_git_dirty:0
collectd_1  | redis_build_id:40c7ff2f04a28f9a
collectd_1  | redis_mode:standalone
collectd_1  | os:Linux 4.4.0-98-generic x86_64
collectd_1  | arch_bits:64
collectd_1  | multiplexing_api:epoll
collectd_1  | atomicvar_api:atomic-builtin
collectd_1  | gcc_version:4.9.2
collectd_1  | process_id:1
collectd_1  | run_id:3dd683bea38359bf8349f15d5c38c918c2adadc0
collectd_1  | tcp_port:6379
collectd_1  | uptime_in_seconds:141
collectd_1  | uptime_in_days:0
collectd_1  | hz:10
collectd_1  | lru_clock:2203799
collectd_1  | executable:/data/redis-server
collectd_1  | config_file:
collectd_1  | 
collectd_1  | # Clients
collectd_1  | connected_clients:1
collectd_1  | client_longest_output_list:0
collectd_1  | client_biggest_input_buf:0
collectd_1  | blocked_clients:0
collectd_1  | 
collectd_1  | # Memory
collectd_1  | used_memory:828264
collectd_1  | used_memory_human:808.85K
collectd_1  | used_memory_rss:9744384
collectd_1  | used_memory_rss_human:9.29M
collectd_1  | used_memory_peak:828264
collectd_1  | used_memory_peak_human:808.85K
collectd_1  | used_memory_peak_perc:100.00%
collectd_1  | used_memory_overhead:815150
collectd_1  | used_memory_startup:765520
collectd_1  | used_memory_dataset:13114
collectd_1  | used_memory_dataset_perc:20.90%
collectd_1  | total_system_memory:8159309824
collectd_1  | total_system_memory_human:7.60G
collectd_1  | used_memory_lua:37888
collectd_1  | used_memory_lua_human:37.
collectd_1  | redis plugin [verbose]: Sending info commandstats command
collectd_1  | redis plugin [verbose]: Received line: $118
collectd_1  | 
collectd_1  | redis plugin [verbose]: Received data: # Commandstats
collectd_1  | cmdstat_info:calls=7,usec=594,usec_per_call=84.86
collectd_1  | cmdstat_cluster:calls=3,usec=6,usec_per_call=2.00
collectd_1  | 
collectd_1  | redis plugin [verbose]: Sending cluster info command
collectd_1  | redis plugin [verbose]: Received line: -ERR This instance has cluster support disabled
collectd_1  | 
collectd_1  | Unhandled python exception in read callback: ValueError: invalid literal for int() with base 10: 'ERR This instance has cluster support disabled\r'
collectd_1  | Traceback (most recent call last):
collectd_1  |   File "/opt/collectd/lib/collectd/plugins/python/redis_info.py", line 232, in read_callback
collectd_1  |     get_metrics(conf)
collectd_1  |   File "/opt/collectd/lib/collectd/plugins/python/redis_info.py", line 236, in get_metrics
collectd_1  |     info = fetch_info(conf)
collectd_1  |   File "/opt/collectd/lib/collectd/plugins/python/redis_info.py", line 98, in fetch_info
collectd_1  |     content_length = int(status_line[1:-1])  # status_line looks like: $<content_length>
collectd_1  | ValueError: invalid literal for int() with base 10: 'ERR This instance has cluster support disabled\r'
collectd_1  | read-function of plugin `python.redis_info' failed. Will suspend it for 160.000 seconds.
```

I've added a new configuration entry to allow disabling the 'cluster info' command. Just a new 'Cluster' boolean config and wrapping all related code within appropiate ifs.
If cluster config not specified, it defaults to True to preserve current behavior.