### PR TITLE
Add example/testing Docker Compose manifest file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,19 @@ Requirements
 ------------
 
  * collectd 4.9+
+
+Devel workflow with Docker & Docker Compose
+-------------------------------------------
+You can start hacking right away by using the provided Docker Compose manifest. No devel packages nor libs need to be installed on development host, just Docker and Docker Compose and you are good to go!
+
+The Compose manifest launches a Redis server container based on ```redis[:latest]``` image (4.x as of Dec'17) and a collectd+python runtime container from ```pataquets/collectd-python``` image. Both containers share the same net iface to connect via ```localhost``` (not a best practice on production, but fair enough for developing). Also, the collectd container mounts from the Docker host's git repo directory:
+
+* The Python program file.
+* The ```redis.conf``` config file.
+* An additional collectd conf file to make al collectd readings to be sent to stdout (using the CSV plugin).
+
+Just hack, change confs and test by doing:
+```
+$ docker-compose up
+```
+Stop by ```CTRL+C```'ing. Rinse and repeat.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+collectd:
+  image: pataquets/collectd-python
+  net: container:redis
+  volumes:
+    - ./redis_info.py:/opt/collectd/lib/collectd/plugins/python/redis_info.py:ro
+    - ./redis.conf:/etc/collectd/conf.d/redis.conf:ro
+    - ./write-csv-stdout.conf:/etc/collectd/conf.d/write-csv-stdout.conf:ro
+
+redis:
+  image: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ collectd:
 
 redis:
   image: redis
+  #command: --loglevel verbose

--- a/write-csv-stdout.conf
+++ b/write-csv-stdout.conf
@@ -1,0 +1,5 @@
+# This configuration file is meant for debugging purposes.
+LoadPlugin "csv"
+<Plugin "csv">
+  DataDir "stdout"
+</Plugin>


### PR DESCRIPTION
To add Docker workflow to hacking options.
No devel packages nor development libs installation needed on development host, just Docker and Docker Compose and you can start hacking! People familiar with Docker will figure out themselves
Run:
```
$ docker-compose up
```
Stop by ```CTRL+C```'ing.

Manifest launches a Redis server container based on ```redis[:latest]``` image (4.x as of now) and a collectd+python runtime container from my ```pataquets/collectd-python``` image. Both containers share the same net iface to connect via ```localhost```.
The collectd container mounts from the Docker host's git repo directory:
* The Python program file.
* The ```redis.conf``` config file.
* An additional collectd conf file to make al collectd readings to be sent to stdout (using the CSV plugin).

Just hack, change confs and test by ```CTRL+C``` and ```up```'ing again. Rinse and repeat.